### PR TITLE
Correct Gemfury workflow artifact path

### DIFF
--- a/.github/workflows/reusable-releaser-gemfury.yml
+++ b/.github/workflows/reusable-releaser-gemfury.yml
@@ -103,4 +103,4 @@ jobs:
         working-directory: ${{ steps.artifact.outputs.artifact-dir }}
         run: |
           owner=${{ inputs.owner }}
-          for f in ./*.deb; do curl --fail -F package=@$f https://$FURY_TOKEN@push.fury.io/$owner/; done
+          for f in ./*.rpm; do curl --fail -F package=@$f https://$FURY_TOKEN@push.fury.io/$owner/; done


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->

Change `*.deb` to `*.rpm`

## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/wabarc/.github/blob/main/CONTRIBUTING.md)
- [x] I have reviewed and understood the [Code of Conduct](https://github.com/wabarc/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have searched and make sure there's no duplicate PRs
